### PR TITLE
Create Release Notes

### DIFF
--- a/Release Notes
+++ b/Release Notes
@@ -1,0 +1,6 @@
+Version 1.2.0
+
+GMS detection: When GMS is detected, HMS kits are disabled and GMS AdMob is loaded.
+GMS AdMob (Banner, Interstitial, Reward)
+Separated ad IDs into debug and release variants.
+Fixed various calculator and converter issues.


### PR DESCRIPTION
Version 1.2.0

GMS detection: When GMS is detected, HMS kits are disabled and GMS AdMob is loaded.
GMS AdMob (Banner, Interstitial, Reward)
Separated ad IDs into debug and release variants.
Fixed various calculator and converter issues.